### PR TITLE
test: add a second Expect test case to show a problem with buffering

### DIFF
--- a/gexpect_test.go
+++ b/gexpect_test.go
@@ -19,6 +19,28 @@ func TestHelloWorld(*testing.T) {
 	log.Printf("Success\n")
 }
 
+func TestDoubleHelloWorld(*testing.T) {
+	log.Printf("Testing Double Hello World... ")
+	//child, err := Spawn(`sh -c "echo Hello World ; echo Hello ; echo Hi"`)
+	child, err := Spawn(`sh -c "echo Hello World ; sleep 0.1 ; echo Hello ; sleep 0.1 ; echo Hi"`)
+	if err != nil {
+		panic(err)
+	}
+	err = child.Expect("Hello World")
+	if err != nil {
+		panic(err)
+	}
+	err = child.Expect("Hello")
+	if err != nil {
+		panic(err)
+	}
+	err = child.Expect("Hi")
+	if err != nil {
+		panic(err)
+	}
+	log.Printf("Success\n")
+}
+
 func TestHelloWorldFailureCase(*testing.T) {
 	log.Printf("Testing Hello World Failure case... ")
 	child, err := Spawn("echo \"Hello World\"")


### PR DESCRIPTION
This test shows an issue when there are several `Expect()` following each other: if the previous `Expect()` ate too much bytes from the terminal, the next expect will fail, unless we are lucky with the timing.

gexpect works fine with this timing:
```
echo Hello World ; sleep 0.1 ; echo Hello ; sleep 0.1 ; echo Hi
```
But gexpect fails with this timing:
```
echo Hello World ; echo Hello ; echo Hi
```

This PR does not fix the bug but just shows the problem.
