### PR TITLE
gexpect: capture process stdout/stderr to ease debugging

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -243,6 +243,9 @@ func (expect *ExpectSubprocess) ExpectTimeout(searchString string, timeout time.
 func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
 	chunk := make([]byte, len(searchString)*2)
 	target := len(searchString)
+	if expect.outputBuffer != nil {
+		expect.outputBuffer = expect.outputBuffer[0:]
+	}
 	m := 0
 	i := 0
 	// Build KMP Table
@@ -253,6 +256,9 @@ func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
 
 		if err != nil {
 			return err
+		}
+		if expect.outputBuffer != nil {
+			expect.outputBuffer = append(expect.outputBuffer, chunk[:n]...)
 		}
 		offset := m + i
 		for m+i-offset < n {
@@ -280,6 +286,10 @@ func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
 func (expect *ExpectSubprocess) Send(command string) error {
 	_, err := io.WriteString(expect.buf.f, command)
 	return err
+}
+
+func (expect *ExpectSubprocess) Capture() {
+	expect.outputBuffer = make([]byte, 0)
 }
 
 func (expect *ExpectSubprocess) SendLine(command string) error {


### PR DESCRIPTION
This commit adds a new function Capture() to gexpect. When called before
calling Expect*(), it will save the process output so it can be
recovered later with CollectOutput().

Based on tehnerd's solution:
https://github.com/ThomasRooney/gexpect/pull/4