### PR TITLE
gexpect: make Capture() idempotent

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -291,7 +291,9 @@ func (expect *ExpectSubprocess) Send(command string) error {
 }
 
 func (expect *ExpectSubprocess) Capture() {
-	expect.outputBuffer = make([]byte, 0)
+	if expect.outputBuffer == nil {
+		expect.outputBuffer = make([]byte, 0)
+	}
 }
 
 func (expect *ExpectSubprocess) Collect() []byte {


### PR DESCRIPTION
This way, a function like ExpectWithOutput can be implemented and
substitute calls to Expect without any other changes.

See https://github.com/coreos/rkt/pull/974#issuecomment-107938286