### PR TITLE
Skip tests on Windows

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package gexpect
 
 import (

--- a/gexpect_test.go
+++ b/gexpect_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package gexpect
 
 import (


### PR DESCRIPTION
When using vendoring with `go test ./..`, test will fail on Windows. May as well skip this package, as it's not intended for the windows platform.