### PR TITLE
pty should be closed when Subprocess is closed 

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -5,14 +5,15 @@ package gexpect
 import (
 	"bytes"
 	"errors"
-	shell "github.com/kballard/go-shellquote"
-	"github.com/kr/pty"
 	"io"
 	"os"
 	"os/exec"
 	"regexp"
 	"time"
 	"unicode/utf8"
+
+	shell "github.com/kballard/go-shellquote"
+	"github.com/kr/pty"
 )
 
 type ExpectSubprocess struct {
@@ -141,6 +142,7 @@ func Spawn(command string) (*ExpectSubprocess, error) {
 }
 
 func (expect *ExpectSubprocess) Close() error {
+	expect.buf.f.Close()
 	return expect.Cmd.Process.Kill()
 }
 

--- a/gexpect.go
+++ b/gexpect.go
@@ -142,8 +142,13 @@ func Spawn(command string) (*ExpectSubprocess, error) {
 }
 
 func (expect *ExpectSubprocess) Close() error {
-	expect.buf.f.Close()
-	return expect.Cmd.Process.Kill()
+	if err := expect.Cmd.Process.Kill(); err != nil {
+		return err
+	}
+	if err := expect.buf.f.Close(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (expect *ExpectSubprocess) AsyncInteractChannels() (send chan string, receive chan string) {


### PR DESCRIPTION
pty should be closed when Subprocess is closed as it keeps using up file descriptor until it complains of too many file being open