### PR TITLE
Fix buffer corruption in ReadUntil

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -332,7 +332,7 @@ func (expect *ExpectSubprocess) Interact() {
 }
 
 func (expect *ExpectSubprocess) ReadUntil(delim byte) ([]byte, error) {
-	join := make([]byte, 1, 512)
+	join := make([]byte, 0, 512)
 	chunk := make([]byte, 255)
 
 	for {
@@ -346,7 +346,7 @@ func (expect *ExpectSubprocess) ReadUntil(delim byte) ([]byte, error) {
 		for i := 0; i < n; i++ {
 			if chunk[i] == delim {
 				if len(chunk) > i+1 {
-					expect.buf.PutBack(chunk[i+1:])
+					expect.buf.PutBack(chunk[i+1:n])
 				}
 				return join, nil
 			} else {

--- a/gexpect_test.go
+++ b/gexpect_test.go
@@ -178,3 +178,26 @@ func TestRegexFind(t *testing.T) {
 		}
 	}
 }
+
+func TestReadLine(t *testing.T) {
+	t.Logf("Testing ReadLine...")
+
+	child, err := Spawn("echo -e \"foo\nbar\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s, err := child.ReadLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "foo\r" {
+		t.Fatalf("expected 'foo\\r', got '%s'", s)
+	}
+	s, err = child.ReadLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != "bar\r" {
+		t.Fatalf("expected 'bar\\r', got '%s'", s)
+	}
+}


### PR DESCRIPTION
This fixes two bugs:
1) join initialization prepends a nul character to the return string
2) the call to PutBack puts extra bytes back into the buffer