### PR TITLE
Fix buffer corruption in Expect

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -332,7 +332,7 @@ func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
 				if i == target {
 					unreadIndex := m + i - offset
 					if len(chunk) > unreadIndex {
-						expect.buf.PutBack(chunk[unreadIndex:])
+						expect.buf.PutBack(chunk[unreadIndex:n])
 					}
 					return nil
 				}


### PR DESCRIPTION
Expect was passing the full chunk buffer to PutBack instead of the valid data subslice.