### PR TITLE
fix buffer.ReadRune for multibyte unicode characters

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -72,7 +72,7 @@ func (buf *buffer) ReadRune() (r rune, size int, err error) {
 		if err != nil {
 			return 0, 0, err
 		}
-		if utf8.FullRune(chunk) {
+		if utf8.FullRune(chunk[:n]) {
 			r, rL := utf8.DecodeRune(chunk)
 			if n > rL {
 				buf.PutBack(chunk[rL:n])
@@ -91,7 +91,7 @@ func (buf *buffer) ReadRune() (r rune, size int, err error) {
 		}
 		l = l + fn
 
-		if utf8.FullRune(chunk) {
+		if utf8.FullRune(chunk[:l]) {
 			r, rL := utf8.DecodeRune(chunk)
 			if buf.collect {
 				buf.collection.WriteRune(r)

--- a/gexpect.go
+++ b/gexpect.go
@@ -19,7 +19,6 @@ import (
 
 var (
 	ErrEmptySearch = errors.New("empty search string")
-	ErrTimeout     = errors.New("expect timed out")
 )
 
 type ExpectSubprocess struct {


### PR DESCRIPTION
In buffer.ReadRune the utf.FullRune checks given slice if there is enough
bytes for multibyte utf8 encoded unicode character, but because chunk is always UTFMax long
check is always true, without actually getting remaining bytes to decode rune correctly

This fix passes only slice of actual (according the n for buffer and l for file)
read bytes to FullRune.

Includes unittest for ReadRune with partially filled buffer.b.

This also removes an unused constant.