### PR TITLE
expect: do not prematurely return error on last read

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -318,7 +318,7 @@ func (expect *ExpectSubprocess) Expect(searchString string) (e error) {
 
 	for {
 		n, err := expect.buf.Read(chunk)
-		if err != nil {
+		if n == 0 && err != nil {
 			return err
 		}
 		if expect.outputBuffer != nil {


### PR DESCRIPTION
This commit changes Expect() to not return early errors
on final reads (`EOF` but `n != 0`) in order to avoid discarding
the last bytes from the source buffer. According to Reader interface
next loop iteration will get a (0, EOF) causing this method to
return.