### PR TITLE
the closed threads are leaved as Zombie state

### DIFF
--- a/gexpect.go
+++ b/gexpect.go
@@ -150,6 +150,9 @@ func (expect *ExpectSubprocess) Close() error {
 	if err := expect.Cmd.Process.Kill(); err != nil {
 		return err
 	}
+	if _, err := expect.Cmd.Process.Wait(); err != nil {
+		return err
+	}
 	if err := expect.buf.f.Close(); err != nil {
 		return err
 	}
@@ -387,7 +390,7 @@ func (expect *ExpectSubprocess) ReadUntil(delim byte) ([]byte, error) {
 		for i := 0; i < n; i++ {
 			if chunk[i] == delim {
 				if len(chunk) > i+1 {
-					expect.buf.PutBack(chunk[i+1:n])
+					expect.buf.PutBack(chunk[i+1 : n])
 				}
 				return join, nil
 			} else {


### PR DESCRIPTION
After Killing a thread, the thread is leaved as Zombie state. Need to invoke Wait/Release syscall to release the resource.

Below are the code snip from golang:
```
// Release releases any resources associated with the Process p,
// rendering it unusable in the future.
// Release only needs to be called if Wait is not.
func (p *Process) Release() error {
    return p.release()
}

// Kill causes the Process to exit immediately.
func (p *Process) Kill() error {
    return p.kill()
}

// Wait waits for the Process to exit, and then returns a
// ProcessState describing its status and an error, if any.
// Wait releases any resources associated with the Process.
// On most operating systems, the Process must be a child
// of the current process or an error will be returned.
func (p *Process) Wait() (*ProcessState, error) {
    return p.wait()
}

```